### PR TITLE
FIX For Laravel 10.x dependency update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "psr/http-client": "~1.0",
-    "psr/log": "~1.0",
+    "psr/log": "~1|~2|~3",
     "guzzlehttp/psr7": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "9.5.6",
     "squizlabs/php_codesniffer": "3.5.2",
-    "monolog/monolog": "2.3.1",
+    "monolog/monolog": "2|3",
     "guzzlehttp/guzzle": "~7.2"
   },
   "autoload": {


### PR DESCRIPTION
[Show issue #11](https://github.com/gladyshev/rucaptcha-client/issues/11)

```bash
  Problem 1
    - Root composer.json requires gladyshev/rucaptcha-client 2.0.0 -> satisfiable by gladyshev/rucaptcha-client[v2.0.0].
    - gladyshev/rucaptcha-client v2.0.0 requires psr/log ~1.0 -> found psr/log[1.0.0, ..., 1.1.4] but the package is fixed to 3.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```

Update psr/log to version 3.0.0